### PR TITLE
feat: Add Stellar chains to supported chains for bridge functionality

### DIFF
--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -90,7 +90,7 @@ const getChainLogo = (chainId: number): string => {
 }
 
 // Currently supported chains for payin/payout (USDC only)
-// Sepolia, Base, Arbitrum, Optimism, Polygon
+// Sepolia, Base, Arbitrum, Optimism, Polygon, Stellar Mainnet, Stellar Testnet
 export const supportedChains: SupportedChain[] = [
   {
     ...sepolia,
@@ -126,6 +126,18 @@ export const supportedChains: SupportedChain[] = [
     usdcAddress: USDC_ADDRESSES[polygon.id],
     explorerUrl: 'https://polygonscan.com',
     ecosystem: 'EVM',
+  },
+  {
+    ...stellarMainnet,
+    logo: getChainLogo(stellarMainnet.id),
+    explorerUrl: 'https://stellar.expert/explorer/public',
+    ecosystem: 'Stellar',
+  },
+  {
+    ...stellarTestnet,
+    logo: getChainLogo(stellarTestnet.id),
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
+    ecosystem: 'Stellar',
   },
 ]
 


### PR DESCRIPTION
- Add Stellar Mainnet (ID: 1500) to supportedChains array
- Add Stellar Testnet (ID: 1501) to supportedChains array
- Enable Stellar chains to appear in ChainSelect dropdown
- Users can now select Stellar as destination chain in bridge form
- 'Pay on Stellar' functionality now properly accessible
- Fixes issue where Stellar chains were defined but not selectable