### PR TITLE
feat: Update default App ID to rozoDemoStellar

### DIFF
--- a/src/lib/intentPay.ts
+++ b/src/lib/intentPay.ts
@@ -111,5 +111,5 @@ export const isRouteSupported = (fromChainId: number, toChainId: number): boolea
 
 // Default app configuration (you should replace with your actual app ID)
 export const DEFAULT_INTENT_PAY_CONFIG = {
-  appId: process.env.NEXT_PUBLIC_INTENT_PAY_APP_ID || 'rozo-bridge-demo',
+  appId: process.env.NEXT_PUBLIC_INTENT_PAY_APP_ID || 'rozoDemoStellar',
 }


### PR DESCRIPTION
- Change default App ID from 'rozo-bridge-demo' to 'rozoDemoStellar'
- Better reflects the Stellar integration focus of the bridge
- More descriptive and professional naming convention
- All Intent Pay transactions now use rozoDemoStellar App ID
- Build passes successfully with new configuration