### PR TITLE
refactor: Simplify bridge interface by removing unnecessary selections

### DIFF
--- a/src/components/RozoWalletSelector.tsx
+++ b/src/components/RozoWalletSelector.tsx
@@ -82,7 +82,7 @@ export function RozoWalletSelector({ className }: RozoWalletSelectorProps) {
       <div className="flex gap-2">
         <Button className={cn('flex items-center gap-2', className)}>
           <CreditCard className="h-4 w-4" />
-          Connect Wallet to Pay
+          Connect Wallet
         </Button>
       </div>
     )

--- a/src/lib/intentPay.ts
+++ b/src/lib/intentPay.ts
@@ -53,7 +53,7 @@ export const getUSDCAddress = (chainId: number): Address => {
 // Create unified Intent Pay configuration
 export const createIntentConfig = (params: {
   appId: string
-  fromChainId: number
+  fromChainId?: number // Optional - users choose when they pay
   toChainId?: number // Optional for Stellar transfers
   toAddress?: Address // For EVM transfers
   toStellarAddress?: string // For Stellar transfers
@@ -75,7 +75,7 @@ export const createIntentConfig = (params: {
     toStellarAddress: params.toStellarAddress,
     toUnits: params.amount,
     intent: 'Transfer USDC',
-    preferredChains: [params.fromChainId], // Prefer the source chain
+    preferredChains: params.fromChainId ? [params.fromChainId] : undefined, // Only set if provided
     memo: params.memo,
     externalId: params.externalId,
   }


### PR DESCRIPTION
- Remove 'From Chain' selection since users choose source chain when they pay
- Remove 'Connect Wallet to Pay' button, keep only 'Connect Wallet' for status
- Update createIntentConfig to make fromChainId optional
- Simplify form validation and external ID generation
- Update description text to clarify source chain selection happens during payment
- Clean up unused imports and dependencies
- Build passes successfully with simplified interface