### PR TITLE
fix: update payment configuration for Stellar transfers to use Base c…

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -1,3 +1,4 @@
+
 # Environment Setup Guide
 
 This guide will help you set up the environment variables needed for the Rozo Bridge Demo.

--- a/src/components/IntentPayBridge.tsx
+++ b/src/components/IntentPayBridge.tsx
@@ -13,9 +13,11 @@ import { StellarAddressInput } from './StellarAddressInput'
 import { StellarMemoInput } from './StellarMemoInput'
 import { RozoWalletSelector } from './RozoWalletSelector' // Updated import
 import { RozoPayButton } from '@rozoai/intent-pay'
+import { getAddress } from 'viem'
 import { 
   createIntentConfig, 
-  DEFAULT_INTENT_PAY_CONFIG 
+  DEFAULT_INTENT_PAY_CONFIG,
+  BASE_USDC
 } from '@/lib/intentPay'
 import { isValidStellarAddress } from '@/lib/stellar'
 import { toast } from 'sonner'
@@ -28,8 +30,6 @@ enum MemoType {
   MemoHash = 3,
   MemoReturn = 4,
 }
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const
 
 export function IntentPayBridge() {
   const MIN_USDC_AMOUNT = 0.10
@@ -240,11 +240,11 @@ export function IntentPayBridge() {
               ) : (
                 <RozoPayButton
                   appId={intentConfig.appId}
-                  toChain={intentConfig.toChain!}
-                  toToken={intentConfig.toToken!}
-                  toAddress={ZERO_ADDRESS}
+                  toChain={BASE_USDC.chainId}
+                  toAddress={getAddress("0x0000000000000000000000000000000000000000")}
                   toStellarAddress={intentConfig.toStellarAddress}
                   toUnits={intentConfig.toUnits}
+                  toToken={getAddress(BASE_USDC.token)}
                   {...(intentConfig.memo ? { memo: intentConfig.memo } : {})}
                   onPaymentStarted={handlePaymentStarted}
                   onPaymentCompleted={handlePaymentCompleted}

--- a/src/lib/intentPay.ts
+++ b/src/lib/intentPay.ts
@@ -1,7 +1,13 @@
 // Intent Pay SDK integration
 // Real implementation using @rozoai/intent-pay for gasless, commission-free transfers
 
-import { type Address } from 'viem'
+import { Address } from 'viem'
+
+// Base chain configuration for Stellar transfers
+export const BASE_USDC = {
+  chainId: 8453, // Base chain ID
+  token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' // Base USDC address
+} as const
 
 // Re-export Intent Pay SDK components and types
 export { 
@@ -69,8 +75,8 @@ export const createIntentConfig = (params: {
   
   return {
     appId: params.appId,
-    toChain: params.toChainId || 1, // Use provided chain or default to Ethereum for Stellar
-    toToken: isStellarTransfer ? getUSDCAddress(1) : getUSDCAddress(params.toChainId!),
+    toChain: isStellarTransfer ? BASE_USDC.chainId : params.toChainId!,
+    toToken: isStellarTransfer ? BASE_USDC.token : getUSDCAddress(params.toChainId!),
     toAddress: params.toAddress,
     toStellarAddress: params.toStellarAddress,
     toUnits: params.amount,


### PR DESCRIPTION
…hain

- Add BASE_USDC constant for Base chain configuration
- Update createIntentConfig to use Base chain for Stellar transfers
- Fix RozoPayButton props for Stellar transfers to match correct example
- Use Base chain (8453) as intermediary for Stellar payments
- Ensure proper token address and zero address configuration